### PR TITLE
Remove reading scope from deploymentconfig. .bicep/bicepparam is always master

### DIFF
--- a/src/support-functions.psm1
+++ b/src/support-functions.psm1
@@ -149,11 +149,7 @@ function Resolve-TemplateDeploymentScope {
     $targetScope = ""
     $deploymentFile = Get-Item -Path $DeploymentFilePath
     
-    if ($DeploymentConfig.scope) {
-        Write-Debug "[Resolve-TemplateDeploymentScope()] TargetScope determined by scope property in deploymentconfig.json file"
-        $targetScope = $DeploymentConfig.scope
-    }
-    elseif ($deploymentFile.Extension -eq ".bicep") {
+    if ($deploymentFile.Extension -eq ".bicep") {
         $referenceString = $deploymentFile.Name
     }
     elseif ($deploymentFile.Extension -eq ".bicepparam") {

--- a/src/tests/Resolve-TemplateDeploymentScope.tests.ps1
+++ b/src/tests/Resolve-TemplateDeploymentScope.tests.ps1
@@ -68,4 +68,21 @@ Describe "Resolve-TemplateDeploymentScope.ps1" {
             $templateDeploymentScope | Should -Be 'subscription'
         }
     }
+
+    Context "When scope is defined in deploymentcondif.jsonc" {
+        BeforeAll {
+            $script:param = @{
+                DeploymentFilePath = "$mockDirectory/deployments/deployment/comments/targetScopeCommented.bicepparam"
+                DeploymentConfig   = @{
+                    'managementGroupId' = 'mockMgmtGroupId'
+                    'scope'             = 'subscription'
+                }
+            }
+            $script:templateDeploymentScope = Resolve-TemplateDeploymentScope @param
+        }
+
+        It "Should resolve DeploymentScope to be [subscription]" {
+            $templateDeploymentScope | Should -Be 'subscription'
+        }
+    }
 }

--- a/src/tests/Resolve-TemplateDeploymentScope.tests.ps1
+++ b/src/tests/Resolve-TemplateDeploymentScope.tests.ps1
@@ -69,7 +69,7 @@ Describe "Resolve-TemplateDeploymentScope.ps1" {
         }
     }
 
-    Context "When scope is defined in deploymentcondif.jsonc" {
+    Context "When scope is defined in deploymentconfig.jsonc" {
         BeforeAll {
             $script:param = @{
                 DeploymentFilePath = "$mockDirectory/deployments/deployment/comments/targetScopeCommented.bicepparam"


### PR DESCRIPTION
Fixes #22 

Adds test that failes before fix and succeeds after fix.