### PR TITLE
This change reduces the what-if output for the plan step to not include Ignore and NoChange

### DIFF
--- a/src/DeployBicepHelpers.psm1
+++ b/src/DeployBicepHelpers.psm1
@@ -1003,7 +1003,7 @@ function Resolve-DeploymentConfig {
             }
     
             if ($DeploymentWhatIf) {
-                $azCliCommand += "--what-if"
+                $azCliCommand += "--what-if --what-if-exclude-change-types Ignore NoChange"
             }
         }
 

--- a/src/tests/Resolve-DeploymentConfig.tests.ps1
+++ b/src/tests/Resolve-DeploymentConfig.tests.ps1
@@ -242,17 +242,17 @@ Describe "Resolve-DeploymentConfig" {
             It "Should handle <scenario> correctly" -TestCases @(
                 @{
                     scenario = "no 'DeploymentWhatIf' parameter"
-                    expected = "^(?!.*--what-if).*$"
+                    expected = "^(?!.*--what-if --what-if-exclude-change-types Ignore NoChange).*$"
                 }
                 @{
                     scenario         = "false 'DeploymentWhatIf' parameter"
                     deploymentWhatIf = $false
-                    expected         = "^(?!.*--what-if).*$"
+                    expected         = "^(?!.*--what-if --what-if-exclude-change-types Ignore NoChange).*$"
                 }
                 @{
                     scenario         = "true 'DeploymentWhatIf' parameter"
                     deploymentWhatIf = $true
-                    expected         = "--what-if"
+                    expected         = "--what-if --what-if-exclude-change-types Ignore NoChange"
                 }
             ) {
                 param ($scenario, $deploymentWhatIf, $expected)


### PR DESCRIPTION
This pull request updates the deployment helper and its associated tests to improve the handling of the `--what-if` parameter by excluding certain change types. The main focus is to ensure that when the `DeploymentWhatIf` flag is used, the command now also excludes "Ignore" and "NoChange" types from the what-if results, and the tests are updated to match this new behavior.

Deployment command improvements:

* The `Resolve-DeploymentConfig` function now appends `--what-if --what-if-exclude-change-types Ignore NoChange` instead of just `--what-if` when the `DeploymentWhatIf` flag is set, ensuring that only relevant changes are shown in deployment previews.

Test updates:

* The tests in `Resolve-DeploymentConfig.tests.ps1` are updated to check for the new command format, ensuring that the exclusion of "Ignore" and "NoChange" change types is properly validated in all relevant scenarios.