### PR TITLE
Change to latest version of both azcli and bicep module and add support for bicepVersion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ on:
 jobs:
   deploy-bicep:
     name: Deploy sample-deployment to prod
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment:
       name: prod
     permissions:
@@ -360,7 +360,7 @@ on:
 
 jobs:
   get-bicep-deployments:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read # Required for repo checkout
 
@@ -383,7 +383,7 @@ jobs:
   deploy-bicep-parallel:
     name: "[${{ matrix.Name }}][${{ matrix.Environment }}] Deploy"
     if: "${{ needs.get-bicep-deployments.outputs.deployments != '' && needs.get-bicep-deployments.outputs.deployments != '[]' }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs:
       - get-bicep-deployments
     strategy:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ These options are common for all scenarios
 | disabled        | boolean | false    | Setting this to true disables the deployment regardless of the triggering event.                                                                                 |
 | triggers        | object  | false    | Configures settings per GitHub event trigger. See: [triggers](#triggers)                                                                                         |
 | azureCliVersion | string  | false    | The Azure CLI version to use.                                                                                                                                    |
+| bicepVersion    | string  | false    | The Bicep version to use.                                                                                                                                        |
 | type            | string  | false    | Specifies the execution type. Either `deployment` or `deploymentStack`. Default: `deployment`                                                                    |
 | scope           | string  | false    | Specifies the scope of the deployment or deploymentStack. Valid options: `resourceGroup`, `subscription`, `managementGroup` or `tenant`. Default: `subscription` |
 

--- a/action.yaml
+++ b/action.yaml
@@ -174,9 +174,6 @@ runs:
           echo "Azure CLI version:"
           az version
 
-          echo "Bicep version:"
-          bicep --version
-
           #* Print command
           # Convert to multiline with 2-space indentation and 1 space before backslash
           formatted_cmd=$(echo "$AZURE_CLI_COMMAND" | sed 's/--/\n  --/g')
@@ -193,6 +190,9 @@ runs:
 
           #* Write the result to console
           echo "$deployment_output"
+
+          echo "Bicep version:"
+          az bicep version
 
           #* Write success annotation
           if echo "$deployment_output" | jq -e . >/dev/null 2>&1; then

--- a/action.yaml
+++ b/action.yaml
@@ -182,8 +182,6 @@ runs:
           #* Print versions
           echo "Azure CLI version:"
           az version
-
-          echo "Bicep version:"
           az bicep version
 
           #* Print command

--- a/action.yaml
+++ b/action.yaml
@@ -170,6 +170,16 @@ runs:
             AZURE_CLI_COMMAND="$AZURE_CLI_COMMAND --debug"
           fi
 
+          #* Print versions
+          echo "Azure CLI version:"
+          az version
+
+          echo "Azure CLI embedded Bicep version:"
+          az bicep version
+
+          echo "Bicep version:"
+          bicep --version
+
           #* Print command
           # Convert to multiline with 2-space indentation and 1 space before backslash
           formatted_cmd=$(echo "$AZURE_CLI_COMMAND" | sed 's/--/\n  --/g')

--- a/action.yaml
+++ b/action.yaml
@@ -22,8 +22,7 @@ runs:
     - name: Install PS Modules
       uses: climpr/install-psmodules@v1
       with:
-        modules: |
-          Bicep:2.8.0
+        modules: Bicep
 
     - name: Resolve parameter
       id: get-input

--- a/action.yaml
+++ b/action.yaml
@@ -174,9 +174,6 @@ runs:
           echo "Azure CLI version:"
           az version
 
-          echo "Azure CLI embedded Bicep version:"
-          az bicep version
-
           echo "Bicep version:"
           bicep --version
 

--- a/action.yaml
+++ b/action.yaml
@@ -72,6 +72,7 @@ runs:
           "scope"                = "Scope"
           "azure-cli-version"    = "AzureCliVersion"
           "azure-cli-command"    = "AzureCliCommand"
+          "bicep-version"        = "BicepVersion"
         }
 
         foreach ($output in $outputs.Keys) {
@@ -84,6 +85,7 @@ runs:
       if: steps.resolve-deploymentconfig.outputs.deploy == 'true'
       env:
         AZURE_CLI_COMMAND: ${{ steps.resolve-deploymentconfig.outputs.azure-cli-command }}
+        BICEP_VERSION: ${{ steps.resolve-deploymentconfig.outputs.bicep-version }}
         WHAT_IF: ${{ inputs.what-if }}
         DEBUG: ${{ runner.debug == '1' }}
       with:
@@ -170,9 +172,19 @@ runs:
             AZURE_CLI_COMMAND="$AZURE_CLI_COMMAND --debug"
           fi
 
+          #* Install Az CLI bicep extension
+          if [ "${BICEP_VERSION,,}" = "latest" ]; then
+            az bicep install
+          else
+            az bicep install --version "$BICEP_VERSION"
+          fi
+
           #* Print versions
           echo "Azure CLI version:"
           az version
+
+          echo "Bicep version:"
+          az bicep version
 
           #* Print command
           # Convert to multiline with 2-space indentation and 1 space before backslash
@@ -190,9 +202,6 @@ runs:
 
           #* Write the result to console
           echo "$deployment_output"
-
-          echo "Bicep version:"
-          az bicep version
 
           #* Write success annotation
           if echo "$deployment_output" | jq -e . >/dev/null 2>&1; then

--- a/default.deploymentconfig.json
+++ b/default.deploymentconfig.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/climpr/climpr-schemas/main/schemas/v1.0.0/bicep-deployment/deploymentconfig.json#",
   "location": "westeurope",
-  "azureCliVersion": "latest"
+  "azureCliVersion": "latest",
+  "bicepVersion": "latest"
 }

--- a/default.deploymentconfig.json
+++ b/default.deploymentconfig.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/climpr/climpr-schemas/main/schemas/v1.0.0/bicep-deployment/deploymentconfig.json#",
   "location": "westeurope",
-  "azureCliVersion": "2.72.0"
+  "azureCliVersion": "latest"
 }

--- a/src/DeployBicepHelpers.psm1
+++ b/src/DeployBicepHelpers.psm1
@@ -263,6 +263,9 @@ function Get-DeploymentConfig {
     if ($climprConfig.bicepDeployment -and $climprConfig.bicepDeployment.azureCliVersion) {
         $climprConfigOptions.Add("azureCliVersion", $climprConfig.bicepDeployment.azureCliVersion)
     }
+    if ($climprConfig.bicepDeployment -and $climprConfig.bicepDeployment.bicepVersion) {
+        $climprConfigOptions.Add("bicepVersion", $climprConfig.bicepDeployment.bicepVersion)
+    }
 
     #* Parse most specific deploymentconfig file
     $fileNames = @(
@@ -947,6 +950,7 @@ function Resolve-DeploymentConfig {
     $deploymentObject = [pscustomobject]@{
         Deploy             = $true
         AzureCliVersion    = $deploymentConfig.azureCliVersion
+        BicepVersion       = $deploymentConfig.bicepVersion
         Environment        = $environmentName
         Type               = $deploymentConfig.type ?? "deployment"
         Scope              = Resolve-TemplateDeploymentScope -DeploymentFilePath $deploymentFileRelativePath -DeploymentConfig $deploymentConfig

--- a/src/tests/Get-DeploymentConfig.tests.ps1
+++ b/src/tests/Get-DeploymentConfig.tests.ps1
@@ -37,6 +37,7 @@ Describe "Get-DeploymentConfig" {
             'default.deploymentconfig.jsonc' = @{
                 name            = "default-name"
                 azureCliVersion = "latest"
+                bicepVersion    = "latest"
                 location        = "westeurope"
             } | ConvertTo-Json
         }

--- a/src/tests/Resolve-DeploymentConfig.tests.ps1
+++ b/src/tests/Resolve-DeploymentConfig.tests.ps1
@@ -2,9 +2,10 @@ BeforeAll {
     if ((Get-PSResourceRepository -Name PSGallery).Trusted -eq $false) {
         Set-PSResourceRepository -Name PSGallery -Trusted -Confirm:$false
     }
-    if ((Get-PSResource -Name Bicep -ErrorAction Ignore).Version -lt "2.8.0") {
+    if (!(Get-PSResource -Name Bicep -ErrorAction Ignore)) {
         Install-PSResource -Name Bicep
     }
+    Update-PSResource -Name Bicep
     Import-Module $PSScriptRoot/../DeployBicepHelpers.psm1 -Force
 
     function New-FileStructure {

--- a/src/tests/Resolve-DeploymentConfig.tests.ps1
+++ b/src/tests/Resolve-DeploymentConfig.tests.ps1
@@ -44,6 +44,7 @@ Describe "Resolve-DeploymentConfig" {
             '$schema'         = "https://raw.githubusercontent.com/climpr/climpr-schemas/main/schemas/v1.0.0/bicep-deployment/deploymentconfig.json#"
             'location'        = "westeurope"
             'azureCliVersion' = "latest"
+            'bicepVersion'    = "latest"
         }
         $defaultDeploymentConfig | ConvertTo-Json | Out-File -FilePath $defaultDeploymentConfigPath
 
@@ -220,6 +221,7 @@ Describe "Resolve-DeploymentConfig" {
                 $properties = [ordered]@{
                     Deploy            = $true
                     AzureCliVersion   = $defaultDeploymentConfig.azureCliVersion
+                    BicepVersion      = $defaultDeploymentConfig.bicepVersion
                     Type              = "deployment"
                     Scope             = "subscription"
                     ParameterFile     = $paramFileRelative
@@ -292,6 +294,7 @@ Describe "Resolve-DeploymentConfig" {
                 $properties = [ordered]@{
                     Deploy            = $true
                     AzureCliVersion   = $defaultDeploymentConfig.azureCliVersion
+                    BicepVersion      = $defaultDeploymentConfig.bicepVersion
                     Type              = "deploymentStack"
                     Scope             = "subscription"
                     ParameterFile     = $paramFileRelative

--- a/src/tests/Resolve-ParameterFileTarget.tests.ps1
+++ b/src/tests/Resolve-ParameterFileTarget.tests.ps1
@@ -2,9 +2,10 @@ BeforeAll {
     if ((Get-PSResourceRepository -Name PSGallery).Trusted -eq $false) {
         Set-PSResourceRepository -Name PSGallery -Trusted -Confirm:$false
     }
-    if ((Get-PSResource -Name Bicep -ErrorAction Ignore).Version -lt "2.8.0") {
+    if (!(Get-PSResource -Name Bicep -ErrorAction Ignore)) {
         Install-PSResource -Name Bicep
     }
+    Update-PSResource -Name Bicep
     Import-Module $PSScriptRoot/../DeployBicepHelpers.psm1 -Force
 }
 


### PR DESCRIPTION
This pull request introduces support for specifying the Bicep CLI version in deployment configurations, ensures the correct Bicep version is installed and used during deployments, and updates documentation and tests to reflect these changes. Additionally, it standardizes the runner environment in workflow examples.

**Bicep Version Support**

* Added support for specifying `bicepVersion` in deployment configuration files and the action's inputs, allowing users to control which Bicep CLI version is used (`default.deploymentconfig.json`, `README.md`, `action.yaml`). [[1]](diffhunk://#diff-c16201593d854c78d92c72ac72483e3cd0af5b05e94ee564dfebf0cdece0a25bL4-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R131) [[3]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR75)

* Updated the deployment logic to install the specified Bicep CLI version using the Azure CLI, and print the installed versions for easier troubleshooting (`action.yaml`).

**Code and Test Updates**

* Modified helper functions and tests to handle and verify the `bicepVersion` property, ensuring it is correctly parsed and passed through the deployment process (`src/DeployBicepHelpers.psm1`, `src/tests/Get-DeploymentConfig.tests.ps1`, `src/tests/Resolve-DeploymentConfig.tests.ps1`). [[1]](diffhunk://#diff-147085a0bf54ec37a3506f67cd583a88802510066b4c88444031432f61970f56R266-R268) [[2]](diffhunk://#diff-147085a0bf54ec37a3506f67cd583a88802510066b4c88444031432f61970f56R953) [[3]](diffhunk://#diff-a6c1a1cbc04bba40890070a5ac1c93c5d3156c6b76000c8de46919454571290cR40) [[4]](diffhunk://#diff-7ecafdd5c1ee0e8b7db5d65491577b1a48a0033f2bd8e2cbaa038845c136192aR47) [[5]](diffhunk://#diff-7ecafdd5c1ee0e8b7db5d65491577b1a48a0033f2bd8e2cbaa038845c136192aR224) [[6]](diffhunk://#diff-7ecafdd5c1ee0e8b7db5d65491577b1a48a0033f2bd8e2cbaa038845c136192aR297)

* Improved PowerShell test environment setup to always update the Bicep module, ensuring tests run with the latest version (`src/tests/Resolve-DeploymentConfig.tests.ps1`, `src/tests/Resolve-ParameterFileTarget.tests.ps1`). [[1]](diffhunk://#diff-7ecafdd5c1ee0e8b7db5d65491577b1a48a0033f2bd8e2cbaa038845c136192aL5-R8) [[2]](diffhunk://#diff-006d403e215e9cd7b462bef2c4eb907d0716e730b3b37928bfd5956cd0948660L5-R8)

**Documentation and Workflow Updates**

* Updated workflow examples in the documentation to use `ubuntu-latest` instead of `ubuntu-22.04` for consistency and future-proofing (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L303-R304) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L363-R364) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L386-R387)

* Clarified documentation to include the new `bicepVersion` option and its usage (`README.md`).